### PR TITLE
Upgrade references for .NET 6

### DIFF
--- a/src/Compiler.cs
+++ b/src/Compiler.cs
@@ -1,4 +1,5 @@
-﻿using dotless.Core;
+﻿using System;
+using dotless.Core;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,7 +19,7 @@ namespace WebOptimizer.Dotless
         /// <summary>
         /// Gets the custom key that should be used when calculating the memory cache key.
         /// </summary>
-        public string CacheKey(HttpContext context) => string.Empty;
+        public string CacheKey(HttpContext context, IAssetContext config) => String.Empty;
 
         /// <summary>
         /// Executes the processor on the specified configuration.
@@ -45,5 +46,8 @@ namespace WebOptimizer.Dotless
 
             return Task.CompletedTask;
         }
+
+        
+        
     }
 }

--- a/src/WebOptimizer.Dotless.csproj
+++ b/src/WebOptimizer.Dotless.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\WebOptimizer.Dotless.xml</DocumentationFile>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageTags>less, bundle, minify, optimize, asp.net core, dotless</PackageTags>
@@ -22,7 +22,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="dotless.Core" Version="1.6.7" />
-    <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.250" />
+    <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.348" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/test/WebOptimizer.Dotless.Test.csproj
+++ b/test/WebOptimizer.Dotless.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.250" />
+    <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.348" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This solved issue #5 by just updating the references to .NET 6 and updating to the latest version of LigerShark.WebOptimizer.Core (that is 3.0.348 at the time of writing).

This also solved the issue with the wildcard so my calling code works just as before no breaking changes in the using project.